### PR TITLE
Add empty string check in detect-namespaces

### DIFF
--- a/DataScience/Experimentation.py
+++ b/DataScience/Experimentation.py
@@ -128,7 +128,7 @@ def detect_namespaces(j_obj, ns_set, marginal_set):
         value = kv_entry[1]
 
         # Ignore entries whose key begins with an '_' except _text
-        if key[0] == '_' and key != '_text':
+        if key and key[0] == '_' and key != '_text':
             continue
 
         if type(value) is list:


### PR DESCRIPTION
This bug was causing evaluations run on events with empty string as their action id or context feature id to fail